### PR TITLE
Use proper package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 # Include here only the dependencies for the eWaterCycle wrapped model
 dependencies = [
   "ewatercycle",
-  "HBV-bmi"
+  "HBV"
 ]
 
 # This registers the plugin such that it is discoverable by eWaterCycle


### PR DESCRIPTION
On pypi HBV-bmi does not exist, that is the repo name but the package is called HBV.
This PR corrects the name so it is installable.

Refs https://github.com/eWaterCycle/infra/issues/178